### PR TITLE
Exporta GeoJSON

### DIFF
--- a/src/set_geom.R
+++ b/src/set_geom.R
@@ -26,6 +26,16 @@ votos_sf <- muni_sonora |>
            tolower()) |>
   left_join(votos)
 
+votos_sf <- votos_sf |>
+  mutate(NOMGEO = case_when(CVE_MUN == muni_sonora$CVE_MUN ~ NOMGEO))
+
+dir.create("resultados")
+
+votos_sf |>
+  st_write(dsn = "./resultados/votos_sf.geojson",
+           driver = "GeoJSON",
+           delete_layer = TRUE)
+
 # Haz una primera versión del mapa
 votos_sf |>
   select(VOTOS, geometry) |>


### PR DESCRIPTION
Exporta GeoJSON con la cantidad de votos y la geometría de los municipios de Sonora.

Este GeoJSON servirá para hacer el mapa como resultado.